### PR TITLE
Resolving the 'window is not defined' error by running tests on Jest …

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,8 @@ module.exports = {
   transform: {
     '^.+\\.js$': 'babel-jest',
     '.*\\.(vue)$': 'vue-jest'
-  }
+  },
+  // The default environment in Jest is a Node.js environment. 
+  //If you are building a web app, you can use a browser-like environment through jsdom instead.
+  "testEnvironment": "jsdom"
 }


### PR DESCRIPTION
…and setting jsdom in the jest.config.js file instead.
![jsdom](https://user-images.githubusercontent.com/65049848/148416785-866426db-2683-40b6-9167-54c864c021a1.png)